### PR TITLE
ODPTのAPIClientを追加

### DIFF
--- a/apps/backend/src/constants/odpt.ts
+++ b/apps/backend/src/constants/odpt.ts
@@ -1,0 +1,2 @@
+export const ODPT_API_BASEURL = 'https://api.odpt.org/api/v4/'
+export const ODPT_CHALLENGE_API_BASEURL = ': https://api-challenge2024.odpt.org/api/v4'

--- a/apps/backend/src/factory.ts
+++ b/apps/backend/src/factory.ts
@@ -4,16 +4,22 @@ import { poweredBy } from 'hono/powered-by'
 import { prettyJSON } from 'hono/pretty-json'
 import { trimTrailingSlash } from 'hono/trailing-slash'
 import type OpenAI from 'openai'
+import type { Client } from 'openapi-fetch'
+import type { paths } from './lib/odptApiPath'
 import { aiMiddleware } from './middlewares/ai'
 import { corsMiddleware } from './middlewares/cors'
 
 export type BindingsType = {
   FRONTEND_BASE_URL: string | undefined
+  ODPT_ACCESS_TOKEN: string
+  ODPT_CHALLENGE_ACCESS_TOKEN: string
 }
 
 type VariablesType = {
   aiModel: LanguageModel
   openaiClient: OpenAI
+  odptClient: Client<paths>
+  odptChallengeClient: Client<paths>
 }
 
 type HonoConfigType = {

--- a/apps/backend/src/lib/odptApiPath.ts
+++ b/apps/backend/src/lib/odptApiPath.ts
@@ -1,0 +1,26 @@
+import type { paths } from 'odpt-openapi-generated'
+
+const API_KEY_PROPERTY_NAME = 'acl:consumerKey' as const
+
+type ApiKeyPropertyName = typeof API_KEY_PROPERTY_NAME
+type UsedHttpMethod = 'get'
+
+type OmitApiKey<Path extends object> = {
+  [Endpoint in keyof Path]: {
+    [Property in keyof Path[Endpoint]]: Property extends UsedHttpMethod
+      ? {
+          [MethodProperty in keyof Path[Endpoint][Property]]: MethodProperty extends 'parameters'
+            ? {
+                [Parameter in keyof Path[Endpoint][Property][MethodProperty]]: Parameter extends 'query'
+                  ? Omit<Path[Endpoint][Property][MethodProperty][Parameter], ApiKeyPropertyName>
+                  : Path[Endpoint][Property][MethodProperty][Parameter]
+              }
+            : Path[Endpoint][Property][MethodProperty]
+        }
+      : Path[Endpoint][Property]
+  }
+}
+
+type OmitApiKeyFromPaths = OmitApiKey<paths>
+
+export type { OmitApiKeyFromPaths as paths }

--- a/apps/backend/src/middlewares/odptClient.ts
+++ b/apps/backend/src/middlewares/odptClient.ts
@@ -1,0 +1,32 @@
+import { createMiddleware } from 'hono/factory'
+import createClient, { type Middleware } from 'openapi-fetch'
+import { ODPT_API_BASEURL, ODPT_CHALLENGE_API_BASEURL } from '../constants/odpt'
+import type { paths } from '../lib/odptApiPath'
+
+const openapiClientAuthMiddleware = (apiKey: string) => {
+  return {
+    onRequest: ({ request }) => {
+      const url = new URL(request.url)
+      url.searchParams.append('acl:consumerKey', apiKey)
+      return new Request(url.toString(), request)
+    },
+  } satisfies Middleware
+}
+
+export const odptClientMiddleware = createMiddleware(async (c, next) => {
+  const { ODPT_ACCESS_TOKEN, ODPT_CHALLENGE_ACCESS_TOKEN } = c.env
+  const odptClient = createClient<paths>({
+    baseUrl: ODPT_API_BASEURL,
+  })
+  const odptChallengeClient = createClient<paths>({
+    baseUrl: ODPT_CHALLENGE_API_BASEURL,
+  })
+
+  odptClient.use(openapiClientAuthMiddleware(ODPT_ACCESS_TOKEN))
+  odptChallengeClient.use(openapiClientAuthMiddleware(ODPT_CHALLENGE_ACCESS_TOKEN))
+
+  c.set('odptClient', odptClient)
+  c.set('odptChallengeClient', odptChallengeClient)
+
+  await next()
+})


### PR DESCRIPTION
## issue

resolve #12 

## 概要

`openapi-typescript`で生成した型からapiKeyのパラメータを取り除き、`openapi-fetch`に渡しapiClientを作成。
middlewareでhonoのcontextから環境変数を渡し、honoのvarにセットしている

## 備考

新たに2つの環境変数が必要
- `ODPT_ACCESS_TOKEN`
- `ODPT_CHALLENGE_ACCESS_TOKEN`