### PR TITLE
Fix/odpt

### DIFF
--- a/apps/backend/src/constants/odpt.ts
+++ b/apps/backend/src/constants/odpt.ts
@@ -1,2 +1,2 @@
-export const ODPT_API_BASEURL = 'https://api.odpt.org/api/v4/'
-export const ODPT_CHALLENGE_API_BASEURL = ': https://api-challenge2024.odpt.org/api/v4'
+export const ODPT_API_BASEURL = new URL('https://api.odpt.org/api/v4')
+export const ODPT_CHALLENGE_API_BASEURL = new URL('https://api-challenge2024.odpt.org/api/v4')

--- a/apps/backend/src/lib/odptApiPath.ts
+++ b/apps/backend/src/lib/odptApiPath.ts
@@ -5,16 +5,21 @@ const API_KEY_PROPERTY_NAME = 'acl:consumerKey' as const
 type ApiKeyPropertyName = typeof API_KEY_PROPERTY_NAME
 type UsedHttpMethod = 'get'
 
+type IsEmptyObject<T> = T extends object ? (keyof T extends never ? true : false) : false
+type RemoveEmptyQuery<T extends object> = {
+  [K in keyof T as K extends 'query' ? (IsEmptyObject<T[K]> extends true ? never : K) : K]: T[K]
+}
+
 type OmitApiKey<Path extends object> = {
   [Endpoint in keyof Path]: {
     [Property in keyof Path[Endpoint]]: Property extends UsedHttpMethod
       ? {
           [MethodProperty in keyof Path[Endpoint][Property]]: MethodProperty extends 'parameters'
-            ? {
+            ? RemoveEmptyQuery<{
                 [Parameter in keyof Path[Endpoint][Property][MethodProperty]]: Parameter extends 'query'
                   ? Omit<Path[Endpoint][Property][MethodProperty][Parameter], ApiKeyPropertyName>
                   : Path[Endpoint][Property][MethodProperty][Parameter]
-              }
+              }>
             : Path[Endpoint][Property][MethodProperty]
         }
       : Path[Endpoint][Property]

--- a/apps/backend/src/middlewares/odptClient.ts
+++ b/apps/backend/src/middlewares/odptClient.ts
@@ -23,10 +23,10 @@ export const odptClientMiddleware = createMiddleware(async (c, next) => {
   const { ODPT_ACCESS_TOKEN, ODPT_CHALLENGE_ACCESS_TOKEN } = parse(odptEnvSchema, c.env)
 
   const odptClient = createClient<paths>({
-    baseUrl: ODPT_API_BASEURL,
+    baseUrl: ODPT_API_BASEURL.href,
   })
   const odptChallengeClient = createClient<paths>({
-    baseUrl: ODPT_CHALLENGE_API_BASEURL,
+    baseUrl: ODPT_CHALLENGE_API_BASEURL.href,
   })
 
   odptClient.use(openapiClientAuthMiddleware(ODPT_ACCESS_TOKEN))


### PR DESCRIPTION
- BASE_URLのミス修正とURLコンストラクターを使用するように
- `OmitApiKey`で空の`query`が残ってしまっている問題修正

現行
```ts
odptClient.GET('/datapoints/{DATA_URI}', {
  params: {
    query: {}, //これを指定する必要がある
    path: { DATA_URI: 'odpt.Station:TokyoMetro.Ginza.Ueno' },
  },
})
```

改善後
```ts
odptClient.GET('/datapoints/{DATA_URI}', {
  params: {
    path: { DATA_URI: 'odpt.Station:TokyoMetro.Ginza.Ueno' },
  },
})
```